### PR TITLE
Add default target configuration (and update documentation accordingly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ Restart Home Assistant and add the following section to your *configuration.yaml
 notify:
   - platform: greenapi
     name: greenapi
-    instance_id:  #Set the instanceid
-    token:  #Set the greenapi token.
+    instance_id:  #REQUIRED: Set the instanceid
+    token:  #REQUIRED: Set the greenapi token.
+    target:  #OPTIONAL! Set the detault target. If you set the default target here, you won't have to specify it again in your service calls.
 ```
 
 * instance_id is the Green API instance id.
@@ -80,21 +81,11 @@ notify:
   * For groups, the id should end with *@g.us*
   * For chats, the id should end with *@c.us*
 
-You can also set the default target in your notify service configuration, so that you don't have to specify it every time you call the service.
-Example:
-```yaml
-notify:
-  - platform: greenapi
-    name: me
-    instance_id:  #Set the instanceid
-    token:  #Set the greenapi token.
-    target:  #Set the default target.
-```
-
 
 ## Sending a message
 To Send a message you call the service and provide the following parameters:
 * message (**Required**): Test to send.
+* title (**OPTIONAL**): Add a title for the message in **bold**.
 * target (**OPTIONAL** if you've already defined the default target in your notify service, otherwise required): The chat/group id to send the message to.
 
 ![Send text message](screenshots/text_message.png)

--- a/README.md
+++ b/README.md
@@ -76,15 +76,26 @@ notify:
 
 * instance_id is the Green API instance id.
 * token is the Green API instance token.
-* Target is the chat/contact/group id to send the message to:
+* target is the chat/contact/group id to send the message to:
   * For groups, the id should end with *@g.us*
   * For chats, the id should end with *@c.us*
+
+You can also set the default target in your notify service configuration, so that you don't have to specify it every time you call the service.
+Example:
+```yaml
+notify:
+  - platform: greenapi
+    name: me
+    instance_id:  #Set the instanceid
+    token:  #Set the greenapi token.
+    target:  #Set the default target.
+```
 
 
 ## Sending a message
 To Send a message you call the service and provide the following parameters:
 * message (**Required**): Test to send.
-* target (**Required**): The chat/group id to send the message to.
+* target (**OPTIONAL** if you've already defined the default target in your notify service, otherwise required): The chat/group id to send the message to.
 
 ![Send text message](screenshots/text_message.png)
 
@@ -96,7 +107,7 @@ data:
   target: 972*********@c.us
 ```
 
-### Optional - Attache media to message
+### Optional - Attach media to message
 To send message with media, add the following to the data parameter:
 * file : [Path to the file]
 


### PR DESCRIPTION
This change resolves #1.
The code change was done as an **optional configuration** and doesn't introduce any breaking changes to the schema or the service calls, users can continue using the service and configuration as it was before.
I've also updated the readme.