### PR TITLE
Fix message formatting

### DIFF
--- a/custom_components/greenapi/notify.py
+++ b/custom_components/greenapi/notify.py
@@ -48,7 +48,7 @@ class GreenAPINotificationService(BaseNotificationService):
             title = kwargs.get(ATTR_TITLE)
             if title is not None:
                 title = f"*{title}*"
-                message = f"{title} \n {message}"
+                message = f"{title}\n{message}"
             data = kwargs.get(ATTR_DATA)
             target = kwargs.get(ATTR_TARGET)[0] if kwargs.get(ATTR_TARGET) is not None else self._target #Allow setting the target from either the service-call or the service config. Service call target can override the default config.
             _LOGGER.info(f"Sending message to {target}")


### PR DESCRIPTION
Fix message formatting when it includes a title. The message is indented by a single space, which looks a little untidy.