### PR TITLE
Update manifest.json - typo fix

### DIFF
--- a/custom_components/greenapi/manifest.json
+++ b/custom_components/greenapi/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "greenapi",
-    "name": "Whatsapp notifier basde on Green API",
+    "name": "Whatsapp notifier based on Green API",
     "codeowners": [
     "@t0mer"
     ],


### PR DESCRIPTION
Fixing typo in name "based" instead of "basde"